### PR TITLE
msm8226-common: Correctly start ril-daemon1

### DIFF
--- a/msm8226.mk
+++ b/msm8226.mk
@@ -161,7 +161,8 @@ PRODUCT_PACKAGES += \
     init.crda.sh \
     init.qcom.bt.sh \
     init.qcom.fm.sh \
-    mount_pds.sh
+    init.qcom.ril.sh \
+    mount_pds.sh \
 
 PRODUCT_PACKAGES += \
     init.mmi.boot.sh \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -17,6 +17,13 @@ LOCAL_SRC_FILES    := etc/init.qcom.bt.sh
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE       := init.qcom.ril.sh
+LOCAL_MODULE_TAGS  := optional eng
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES    := etc/init.qcom.ril.sh
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE       := mount_pds.sh
 LOCAL_MODULE_TAGS  := optional eng
 LOCAL_MODULE_CLASS := ETC

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -560,11 +560,6 @@ service mmi-boot-sh /system/bin/sh /init.mmi.boot.sh
     user root
     oneshot
 
-on property:persist.radio.multisim.config=dsds
-    stop ril-daemon
-    start ril-daemon
-    start ril-daemon1
-
 service_redefine ril-daemon /system/bin/rild
     class main
     socket rild stream 660 root radio
@@ -580,6 +575,12 @@ service ril-daemon1 /system/bin/rild -c 2
     user root
     group radio cache inet misc audio sdcard_rw qcom_oncrpc qcom_diag log net_raw diag
     disabled
+
+service rild1-wrapper /system/bin/sh /system/etc/init.qcom.ril.sh
+    class late_start
+    user root
+    group root
+    oneshot
 
 service mmi-touch-sh /system/bin/sh /init.mmi.touch.sh synaptics aps
     class late_start

--- a/rootdir/etc/init.qcom.ril.sh
+++ b/rootdir/etc/init.qcom.ril.sh
@@ -1,0 +1,8 @@
+#!/system/bin/sh
+export PATH=/system/xbin:$PATH
+
+multisim=`getprop persist.radio.multisim.config`
+
+if [ "$multisim" = "dsds" ] || [ "$multisim" = "dsda" ]; then
+    start ril-daemon1
+fi


### PR DESCRIPTION
* Using the dsds/dsda property fails to properly support the encryption
  usecase. Set up a wrapper script that is subject to the same
  start/restart timing as the actual RIL daemon.

Change-Id: Iaf270587399aa4601b06ef72139014cb3a33fd43